### PR TITLE
Avoid running under Hosted Agents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Buildkite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -10,6 +10,11 @@ set -o pipefail
 # processing. The worst that can happen is the cache gets stale and future jobs
 # will have to do a bit morework. That's preferable to failing this job.
 
+if [[ "$BUILDKITE_COMPUTE_TYPE" == "hosted" ]]; then
+  echo "Hosted Agents has built in git caching. Skipping S3 caching implementation."
+  exit 0
+fi
+
 BUCKET="$BUILDKITE_PLUGIN_GIT_CACHE_S3_BUCKET"
 REPO_PATH="${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/git/"
 ONE_DAY_IN_SECONDS=86400

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -14,6 +14,11 @@ set -o pipefail
 # download and decompress it. However if any command fails, we always exit 0 so the checkout hook can
 # do its job, just without the speed or cost benefit of a warm cache.
 
+if [[ "$BUILDKITE_COMPUTE_TYPE" == "hosted" ]]; then
+  echo "Hosted Agents has built in git caching. Skipping S3 caching implementation."
+  exit 0
+fi
+
 BUCKET="$BUILDKITE_PLUGIN_GIT_CACHE_S3_BUCKET"
 REPO_PATH="${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/git/"
 TMP_TARBALL="/tmp/${BUILDKITE_PIPELINE_SLUG}-$(date +%s).git.tar"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: git-cache-s3
 description: Download Git Repos from a local S3 bucket for free
-author: https://github.com/yob
+author: https://github.com/buildkite
 requirements:
   - aws
 configuration:


### PR DESCRIPTION
Hosted Agents has its own git cache implementation, making this plugin
redundant in such environments. In addition, the `git` commands fail due
to permissions issues in Hosted Agents environments:

```
fatal: detected dubious ownership in repository...
```

We still want to keep using this plugin in our pipelines so we can more
easily switch between hosted vs. self-hosted agents, which is why a
guard clause is preferable here.